### PR TITLE
Bump to version 0.2.0

### DIFF
--- a/prsw/__init__.py
+++ b/prsw/__init__.py
@@ -11,4 +11,4 @@ https://stat.ripe.net/docs/data_api
 
 from .ripe_stat import RIPEstat
 
-__version__ = "0.1.2"
+__version__ = "0.2.0"


### PR DESCRIPTION
Bump version number to `0.2.0` for periodic release of new features.