### PR TITLE
Update __init__.py

### DIFF
--- a/prsw/__init__.py
+++ b/prsw/__init__.py
@@ -11,4 +11,4 @@ https://stat.ripe.net/docs/data_api
 
 from .ripe_stat import RIPEstat
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"


### PR DESCRIPTION
Version bump for updated RIPEstat added "data_call_name" key to the output data structure. See #29