### PR TITLE
Added pipeline field to API response

### DIFF
--- a/prsw/api.py
+++ b/prsw/api.py
@@ -27,6 +27,7 @@ class Output:
         process_time: Optional[int] = 0,
         server_id: Optional[str] = "",
         build_version: Optional[str] = "",
+        pipeline: Optional[str] = "",
         status: Optional[str] = "",
         status_code: Optional[int] = 0,
         time: Optional[str] = "",
@@ -46,6 +47,7 @@ class Output:
             self.process_time = int(process_time)
             self.server_id = str(server_id)
             self.build_version = str(build_version)
+            self.pipeline = str(pipeline)
             self.status = str(status)
             self.status_code = int(status_code)
             self.time = datetime.datetime.fromisoformat(time)

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -19,6 +19,7 @@ class TestApi(UnitTest):
         "process_time": 0,
         "server_id": "",
         "build_version": "",
+        "pipeline": "1014856",
         "status": "ok",
         "status_code": 200,
         "time": "2021-04-14T14:16:02.142290",


### PR DESCRIPTION
Some API responses contain additional "pipeline" field which breaks Output class initialization